### PR TITLE
Deploy examples

### DIFF
--- a/deploy/automated/_ingress.yaml
+++ b/deploy/automated/_ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: river-data
+spec:
+  rules:
+  - host: fix.me
+    http:
+      paths:
+      - backend:
+          service:
+            name: river-data
+            port:
+              number: 80
+        path: /
+        pathType: Prefix

--- a/deploy/automated/_river-data-deployment.yaml
+++ b/deploy/automated/_river-data-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: river-data
+spec:
+  selector:
+    matchLabels:
+      app: river-data
+  template:
+    metadata:
+      labels:
+        app: river-data
+    spec:
+      containers:
+        - name: river-data
+          image: ghcr.io/kingdonb/river-data-explorer:0.0.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: river-data
+  namespace: app
+spec:
+  ports:
+    - name: http
+      port: 80
+  selector:
+    app: river-data

--- a/deploy/automated/_river-data-deployment.yaml
+++ b/deploy/automated/_river-data-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: river-data
-          image: ghcr.io/kingdonb/river-data-explorer:0.0.1 # {"$imagepolicy": "river-data:stable"}
+          image: ghcr.io/kingdonb/river-data-explorer:0.0.1 # {"$imagepolicy": "river-auto:stable"}
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/deploy/automated/_river-data-deployment.yaml
+++ b/deploy/automated/_river-data-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: river-data
-          image: ghcr.io/kingdonb/river-data-explorer:0.0.1
+          image: ghcr.io/kingdonb/river-data-explorer:0.0.1 # {"$imagepolicy": "river-data:stable"}
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/deploy/automated/flux-system-rw-gitrepo.yaml
+++ b/deploy/automated/flux-system-rw-gitrepo.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: flux-system-rw
+  namespace: river-data
+spec:
+  gitImplementation: go-git
+  interval: 30m0s
+  ref:
+    branch: main
+  secretRef:
+    name: flux-system-rw
+  timeout: 20s
+  url: ssh://git@github.com/kingdonb/tailscale-k8s

--- a/deploy/automated/flux-system-rw-gitrepo.yaml
+++ b/deploy/automated/flux-system-rw-gitrepo.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
-  name: flux-system-rw
+  name: river-data-rw
   namespace: river-data
 spec:
   gitImplementation: go-git
@@ -10,6 +10,6 @@ spec:
   ref:
     branch: main
   secretRef:
-    name: flux-system-rw
+    name: river-data-rw
   timeout: 20s
-  url: ssh://git@github.com/kingdonb/tailscale-k8s
+  url: ssh://git@github.com/kingdonb/river-data-explorer

--- a/deploy/automated/imageauto.yaml
+++ b/deploy/automated/imageauto.yaml
@@ -8,18 +8,18 @@ spec:
   git:
     checkout:
       ref:
-        branch: deploy
+        branch: main
     commit:
       author:
         email: yebyen+fluxcd@gmail.com
         name: fluxcdbot
       messageTemplate: '{{range .Updated.Images}}{{println .}}{{end}}'
     push:
-      branch: deploy
+      branch: main
   interval: 1m0s
   sourceRef:
     kind: GitRepository
     name: river-data-rw
   update:
-    path: ./deploy/
+    path: ./deploy/automated
     strategy: Setters

--- a/deploy/automated/imageauto.yaml
+++ b/deploy/automated/imageauto.yaml
@@ -8,18 +8,18 @@ spec:
   git:
     checkout:
       ref:
-        branch: main
+        branch: deploy
     commit:
       author:
         email: yebyen+fluxcd@gmail.com
         name: fluxcdbot
       messageTemplate: '{{range .Updated.Images}}{{println .}}{{end}}'
     push:
-      branch: main
+      branch: deploy
   interval: 1m0s
   sourceRef:
     kind: GitRepository
     name: river-data-rw
   update:
-    path: ./deploy/automated
+    path: ./deploy/
     strategy: Setters

--- a/deploy/automated/imageauto.yaml
+++ b/deploy/automated/imageauto.yaml
@@ -2,7 +2,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImageUpdateAutomation
 metadata:
-  name: river-data-stg
+  name: river-data-auto-update
   namespace: river-data
 spec:
   git:
@@ -19,7 +19,7 @@ spec:
   interval: 1m0s
   sourceRef:
     kind: GitRepository
-    name: flux-system-rw
+    name: river-data-rw
   update:
-    path: ./apps/worker/river-data-explorer
+    path: ./deploy/automated
     strategy: Setters

--- a/deploy/automated/imageauto.yaml
+++ b/deploy/automated/imageauto.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageUpdateAutomation
+metadata:
+  name: river-data-stg
+  namespace: river-data
+spec:
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: yebyen+fluxcd@gmail.com
+        name: fluxcdbot
+      messageTemplate: '{{range .Updated.Images}}{{println .}}{{end}}'
+    push:
+      branch: main
+  interval: 1m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system-rw
+  update:
+    path: ./apps/worker/river-data-explorer
+    strategy: Setters

--- a/deploy/automated/imagepolicy.yaml
+++ b/deploy/automated/imagepolicy.yaml
@@ -2,14 +2,52 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
-  name: example
+  name: latest-any
   namespace: river-data
 spec:
   imageRepositoryRef:
-    name: river-data-example
+    name: river-data-explorer
   filterTags:
     pattern: '^.*-[a-fA-F0-9]+-(?P<ts>.*)'
     extract: '$ts'
   policy:
     numerical:
       order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: edge
+  namespace: river-data
+spec:
+  imageRepositoryRef:
+    name: river-data-explorer
+  filterTags:
+    pattern: '.*-edge.*'
+  policy:
+    semver:
+      range: ^1.x-0
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: prerelease
+  namespace: river-data
+spec:
+  imageRepositoryRef:
+    name: river-data-explorer
+  policy:
+    semver:
+      range: '>=0.0.0 <1.0.0'
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: stable
+  namespace: river-data
+spec:
+  imageRepositoryRef:
+    name: river-data-explorer
+  policy:
+    semver:
+      range: '>=1.0.0'

--- a/deploy/automated/imagepolicy.yaml
+++ b/deploy/automated/imagepolicy.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: example
+  namespace: river-data
+spec:
+  imageRepositoryRef:
+    name: river-data-example
+  filterTags:
+    pattern: '^.*-[a-fA-F0-9]+-(?P<ts>.*)'
+    extract: '$ts'
+  policy:
+    numerical:
+      order: asc

--- a/deploy/automated/imagerepo.yaml
+++ b/deploy/automated/imagerepo.yaml
@@ -2,7 +2,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImageRepository
 metadata:
-  name: river-data-example
+  name: river-data-explorer
   namespace: river-data
 spec:
   image: ghcr.io/kingdonb/river-data-explorer

--- a/deploy/automated/imagerepo.yaml
+++ b/deploy/automated/imagerepo.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: river-data-example
+  namespace: river-data
+spec:
+  image: ghcr.io/kingdonb/river-data-explorer
+  interval: 1m0s

--- a/deploy/automated/ingress-patch.yaml
+++ b/deploy/automated/ingress-patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: river-data
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: river-data.hephy.pro
+    http:
+      paths:
+      - backend:
+          service:
+            name: river-data
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - river-data.hephy.pro
+    secretName: river-data-tls

--- a/deploy/automated/ingress-patch.yaml
+++ b/deploy/automated/ingress-patch.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: river-data.hephy.pro
+  - host: river-data-stg.tailscale-k8s.hephy.pro
     http:
       paths:
       - backend:
@@ -19,5 +19,5 @@ spec:
         pathType: Prefix
   tls:
   - hosts:
-    - river-data.hephy.pro
-    secretName: river-data-tls
+    - river-data-stg.tailscale-k8s.hephy.pro
+    secretName: river-data-stg-tls

--- a/deploy/automated/kustomization.yaml
+++ b/deploy/automated/kustomization.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: river-data
+namespace: river-auto
 resources:
   - namespace.yaml
   - imagerepo.yaml
@@ -14,5 +14,4 @@ resources:
 
 patchesStrategicMerge:
   - river-data-patch.yaml
-  #- ingressroute-patch.yaml
   - ingress-patch.yaml

--- a/deploy/automated/kustomization.yaml
+++ b/deploy/automated/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: river-data
+resources:
+  - namespace.yaml
+  - imagerepo.yaml
+  - imagepolicy.yaml
+  # read-write for image update automation
+  - imageauto.yaml
+  - flux-system-rw-gitrepo.yaml
+  - _river-data-deployment.yaml
+  - _ingress.yaml
+
+patchesStrategicMerge:
+  - river-data-patch.yaml
+  #- ingressroute-patch.yaml
+  - ingress-patch.yaml

--- a/deploy/automated/namespace.yaml
+++ b/deploy/automated/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: river-data

--- a/deploy/automated/river-data-patch.yaml
+++ b/deploy/automated/river-data-patch.yaml
@@ -1,0 +1,11 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: river-data
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: river-data
+        image: ghcr.io/kingdonb/river-data-explorer:1.0.0-edge.0 # {"$imagepolicy": "river-data:edge"}

--- a/deploy/automated/river-data-patch.yaml
+++ b/deploy/automated/river-data-patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: river-data
-        image: ghcr.io/kingdonb/river-data-explorer:1.0.0-edge.0 # {"$imagepolicy": "river-data:edge"}
+        image: ghcr.io/kingdonb/river-data-explorer:1.0.0-edge.0 # {"$imagepolicy": "river-auto:edge"}

--- a/deploy/dev/gitrepo-patch.yaml
+++ b/deploy/dev/gitrepo-patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: river-data-rw
+  namespace: river-dev
+spec:
+  gitImplementation: go-git
+  interval: 30m0s
+  ref:
+    branch: main
+  secretRef:
+    name: river-data-rw
+  timeout: 20s
+  url: ssh://git@github.com/kingdonb/river-data-explorer

--- a/deploy/dev/gitrepo-patch.yaml
+++ b/deploy/dev/gitrepo-patch.yaml
@@ -2,7 +2,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: river-data-rw
-  namespace: river-dev
+  namespace: river-auto
 spec:
   gitImplementation: go-git
   interval: 30m0s
@@ -11,4 +11,4 @@ spec:
   secretRef:
     name: river-data-rw
   timeout: 20s
-  url: ssh://git@github.com/kingdonb/river-data-explorer
+  url: ssh://git@github.com/juozasg/river-data-explorer

--- a/deploy/dev/ingress-patch.yaml
+++ b/deploy/dev/ingress-patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: river-data
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: river-data.dev.hephy.pro
+    http:
+      paths:
+      - backend:
+          service:
+            name: river-data
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - river-data.dev.hephy.pro
+    secretName: river-data-tls

--- a/deploy/dev/kustomization.yaml
+++ b/deploy/dev/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: river-dev
+bases:
+  - ../automated
+
+patchesStrategicMerge:
+  - river-data-patch.yaml
+  - ingress-patch.yaml
+  - gitrepo-patch.yaml

--- a/deploy/dev/river-data-patch.yaml
+++ b/deploy/dev/river-data-patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: river-data
-        image: ghcr.io/kingdonb/river-data-explorer:1.0.0-edge.0 # {"$imagepolicy": "river-auto:latest-any"}
+        image: ghcr.io/kingdonb/river-data-explorer:deploy-5813b5ca-1656696777 # {"$imagepolicy": "river-auto:latest-any"}

--- a/deploy/dev/river-data-patch.yaml
+++ b/deploy/dev/river-data-patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: river-data
-        image: ghcr.io/kingdonb/river-data-explorer:deploy-5813b5ca-1656696777 # {"$imagepolicy": "river-auto:latest-any"}
+        image: ghcr.io/kingdonb/river-data-explorer:deploy-4ae46c49-1656697309 # {"$imagepolicy": "river-auto:latest-any"}

--- a/deploy/dev/river-data-patch.yaml
+++ b/deploy/dev/river-data-patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: river-data
-        image: ghcr.io/kingdonb/river-data-explorer:deploy-4ae46c49-1656697309 # {"$imagepolicy": "river-auto:latest-any"}
+        image: ghcr.io/kingdonb/river-data-explorer:deploy-4ae46c49-1656697309 # {"$imagepolicy": "river-dev:latest-any"}

--- a/deploy/dev/river-data-patch.yaml
+++ b/deploy/dev/river-data-patch.yaml
@@ -1,0 +1,11 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: river-data
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: river-data
+        image: ghcr.io/kingdonb/river-data-explorer:1.0.0-edge.0 # {"$imagepolicy": "river-data:latest-any"}

--- a/deploy/dev/river-data-patch.yaml
+++ b/deploy/dev/river-data-patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: river-data
-        image: ghcr.io/kingdonb/river-data-explorer:1.0.0-edge.0 # {"$imagepolicy": "river-data:latest-any"}
+        image: ghcr.io/kingdonb/river-data-explorer:1.0.0-edge.0 # {"$imagepolicy": "river-auto:latest-any"}

--- a/deploy/stable/_ingress.yaml
+++ b/deploy/stable/_ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: river-data
+spec:
+  rules:
+  - host: fix.me
+    http:
+      paths:
+      - backend:
+          service:
+            name: river-data
+            port:
+              number: 80
+        path: /
+        pathType: Prefix

--- a/deploy/stable/deployment.yaml
+++ b/deploy/stable/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: river-data
+spec:
+  selector:
+    matchLabels:
+      app: river-data
+  template:
+    metadata:
+      labels:
+        app: river-data
+    spec:
+      containers:
+        - name: river-data
+          image: ghcr.io/kingdonb/river-data-explorer:0.0.1 # {"$imagepolicy": "river-data:stable"}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: river-data
+  namespace: app
+spec:
+  ports:
+    - name: http
+      port: 80
+  selector:
+    app: river-data

--- a/deploy/stable/ingress-patch.yaml
+++ b/deploy/stable/ingress-patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: river-data
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: river-data.hephy.pro
+    http:
+      paths:
+      - backend:
+          service:
+            name: river-data
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - river-data.hephy.pro
+    secretName: river-data-tls

--- a/deploy/stable/kustomization.yaml
+++ b/deploy/stable/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: river-data
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - _ingress.yaml
+
+patchesStrategicMerge:
+  - river-data-patch.yaml
+  - ingress-patch.yaml

--- a/deploy/stable/namespace.yaml
+++ b/deploy/stable/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: river-data

--- a/deploy/stable/river-data-patch.yaml
+++ b/deploy/stable/river-data-patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: river-data
-        image: ghcr.io/kingdonb/river-data-explorer:1.0.0-edge.0 # {"$imagepolicy": "river-auto:prerelease"}
+        image: ghcr.io/kingdonb/river-data-explorer:0.5.2 # {"$imagepolicy": "river-auto:prerelease"}

--- a/deploy/stable/river-data-patch.yaml
+++ b/deploy/stable/river-data-patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: river-data
-        image: ghcr.io/kingdonb/river-data-explorer:1.0.0-edge.0 # {"$imagepolicy": "river-data:prerelease"}
+        image: ghcr.io/kingdonb/river-data-explorer:1.0.0-edge.0 # {"$imagepolicy": "river-auto:prerelease"}

--- a/deploy/stable/river-data-patch.yaml
+++ b/deploy/stable/river-data-patch.yaml
@@ -1,0 +1,11 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: river-data
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: river-data
+        image: ghcr.io/kingdonb/river-data-explorer:1.0.0-edge.0 # {"$imagepolicy": "river-data:prerelease"}


### PR DESCRIPTION
We need some config in order for CI to deploy it via OCI.

The intention is that on tag publish actions, OCI config will capture the snapshot and Flux will deploy it as soon as it is ready. OCI publish step should run after the Docker build and push completes, to avoid that any config for image is promoted which fails to build and push. It would be nice to use Flux image automation to keep the release artifacts up to date within the tag, but the order likely necessitates that the manifest is updated before the tag goes in so this will not be possible.

This complicates the order of releases in the `stable` channel just a bit, but it will get un-complicated again very soon as we introduce a second tagging scheme for OCI releases.

(The `release/*` exception [here](https://github.com/kingdonb/river-data-explorer/blob/b1a3d0f4b94deb02bd9274adeeaea82ebc935e59/.github/workflows/docker-build.yaml#L8) which has previously gone un-explained is about to get explained)

The space that we have left open for our release workflow to use Git tags in order for OCI artifacts to be promoted after the image has already been tagged, pushed, and released, so that the Docker image push happens-before the next OCI config artifact is promoted but both steps can be automated.

Restated maybe clearer with bullet points (these are not all in scope for this PR, but will come soon):
* When a release is tagged eg. `1.0.0` the CI runs tests, builds the image, and pushes to GHCR.
* Upon successful push of a tag (non pre-release), Flux detects the new image and pushes the change to `deploy/stable`
* The Auto-PR workflow is used to promote it where a dev can merge it to release
* When the Auto-PR is merged, some automation should trigger a tag `release/1.0.0` which triggers the OCI config job
* Flux automation detects the new OCI stable config and deploys it directly as it is a stable release that matches the policy 👍 