### PR TITLE
OCI experiment

### DIFF
--- a/deploy/automated/configrepo.yaml
+++ b/deploy/automated/configrepo.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: river-data-explorer-config
+  namespace: river-data
+spec:
+  image: ghcr.io/kingdonb/river-data-explorer-config
+  interval: 1m0s

--- a/deploy/automated/imageauto.yaml
+++ b/deploy/automated/imageauto.yaml
@@ -21,5 +21,5 @@ spec:
     kind: GitRepository
     name: river-data-rw
   update:
-    path: ./deploy/automated
+    path: ./deploy
     strategy: Setters

--- a/deploy/automated/imagepolicy.yaml
+++ b/deploy/automated/imagepolicy.yaml
@@ -31,6 +31,20 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
+  name: edge-config
+  namespace: river-data
+spec:
+  imageRepositoryRef:
+    name: river-data-explorer-config
+  filterTags:
+    pattern: '.*-edge.*'
+  policy:
+    semver:
+      range: ^0.x-0
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
   name: prerelease
   namespace: river-data
 spec:

--- a/deploy/experiment/flux-kustomization.yaml
+++ b/deploy/experiment/flux-kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: river-data-oci
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  path: ./stable
+  prune: true
+  sourceRef:
+    kind: OCIRepository
+    name: river-data-oci
+  targetNamespace: default
+  timeout: 2m0s
+  wait: true

--- a/deploy/experiment/kustomization.yaml
+++ b/deploy/experiment/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- flux-kustomization.yaml
+- ocirepository.yaml

--- a/deploy/experiment/ocirepository.yaml
+++ b/deploy/experiment/ocirepository.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: river-data-oci
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    tag: 0.5.3-edge.3 # {"$imagepolicy": "river-auto:edge-config"}
+  url: ghcr.io/kingdonb/river-data-explorer-config


### PR DESCRIPTION
The support is further automation which keeps the Flux OCI reference up to date, so we can get automation in prod and keep full GitOps

Signed-off-by: Kingdon Barrett <kingdon@weave.works>