### PR TITLE
Deploy from experiment or dev

### DIFF
--- a/deploy/dev/gitrepo-patch.yaml
+++ b/deploy/dev/gitrepo-patch.yaml
@@ -11,4 +11,4 @@ spec:
   secretRef:
     name: river-data-rw
   timeout: 20s
-  url: ssh://git@github.com/juozasg/river-data-explorer
+  url: ssh://git@github.com/kingdonb/river-data-explorer

--- a/deploy/dev/imageauto-patch.yaml
+++ b/deploy/dev/imageauto-patch.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageUpdateAutomation
+metadata:
+  name: river-data-auto-update
+  namespace: river-data
+spec:
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: yebyen+fluxcd@gmail.com
+        name: fluxcdbot
+      messageTemplate: '[skip ci] {{range .Updated.Images}}{{println .}}{{end}}'
+    push:
+      branch: main
+  interval: 30s
+  sourceRef:
+    kind: GitRepository
+    name: river-data-rw
+  update:
+    path: ./deploy
+    strategy: Setters

--- a/deploy/dev/kustomization.yaml
+++ b/deploy/dev/kustomization.yaml
@@ -9,3 +9,4 @@ patchesStrategicMerge:
   - river-data-patch.yaml
   - ingress-patch.yaml
   - gitrepo-patch.yaml
+  - imageauto-patch.yaml

--- a/deploy/dev/river-data-patch.yaml
+++ b/deploy/dev/river-data-patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: river-data
-        image: ghcr.io/kingdonb/river-data-explorer:main-ca4c5b2a-1656765815 # {"$imagepolicy": "river-dev:latest-any"}
+        image: ghcr.io/kingdonb/river-data-explorer:main-ef91a4e5-1656776506 # {"$imagepolicy": "river-dev:latest-any"}

--- a/deploy/dev/river-data-patch.yaml
+++ b/deploy/dev/river-data-patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: river-data
-        image: ghcr.io/kingdonb/river-data-explorer:deploy-4ae46c49-1656697309 # {"$imagepolicy": "river-dev:latest-any"}
+        image: ghcr.io/kingdonb/river-data-explorer:main-ca4c5b2a-1656765815 # {"$imagepolicy": "river-dev:latest-any"}

--- a/deploy/experiment/flux-kustomization.yaml
+++ b/deploy/experiment/flux-kustomization.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m0s
-  path: ./stable
+  path: ./deploy/stable
   prune: true
   sourceRef:
     kind: OCIRepository

--- a/deploy/experiment/flux-kustomization.yaml
+++ b/deploy/experiment/flux-kustomization.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m0s
-  path: ./deploy/stable
+  path: ./deploy/latest
   prune: true
   sourceRef:
     kind: OCIRepository

--- a/deploy/experiment/kustomization.yaml
+++ b/deploy/experiment/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- ../automated
 - flux-kustomization.yaml
 - ocirepository.yaml


### PR DESCRIPTION
The intention of the `dev` deploy target was to provide the same experience on any fork, without encumbering the user with all the automated/staging/stable/production stuff.

This still incorporates the `automated` part as a resource base, from the `experiment` example in:

* https://github.com/juozasg/river-data-explorer/pull/2

Instructions for use:

```
kind create cluster
flux install --components-extra=image-automation-controller,image-reflector-controller
kubectl apply -k deploy/dev
flux create secret git -n river-dev --url ssh://git@github.com/kingdonb/river-data-explorer river-data-rw
```

You should wind up with a new commit on the main branch (prefixed with a `[ci skip]` to avoid circular loops) after each new image is built based on the `latest-any` ImagePolicy:

```
$ kg imagepolicy
NAMESPACE   NAME          LATESTIMAGE
river-dev   edge          ghcr.io/kingdonb/river-data-explorer:0.5.4
river-dev   edge-config   ghcr.io/kingdonb/river-data-explorer-config:0.5.4
river-dev   latest-any    ghcr.io/kingdonb/river-data-explorer:main-ef91a4e5-1656776506
river-dev   prerelease    ghcr.io/kingdonb/river-data-explorer:0.5.4
river-dev   stable
```

(Production systems would apply the config instead from `edge`, `prerelease`, or `stable` when available. The `edge-config` is the policy for the OCI config repo experiment.)