### PR TITLE
Pin OCI preview at commit version that works

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -90,7 +90,7 @@ jobs:
         id: oci_push
         if: github.event_name == 'push' && github.ref_type == 'tag'
         run: |
-          flux push artifact oci://${{ env.IMAGE }}:${{ steps.prep.outputs.GIT_TAG }} \
+          flux push artifact ${{ env.IMAGE }}:${{ steps.prep.outputs.GIT_TAG }} \
             --path="./deploy" \
             --source="$(git config --get remote.origin.url)" \
             --revision="$(git branch --show-current)/$(git rev-parse HEAD)"

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -24,8 +24,14 @@ jobs:
         run: |
           GIT_TAG=${GITHUB_REF/refs\/tags\/release\//}
           FLUX_PATH=${GITHUB_WORKSPACE}/bin
-          git clone --depth 1 https://github.com/fluxcd/flux2 -b oci
-          pushd flux2
+          FLUX_OCI_SHA=0c89b8d4be118a86e2aea157a64fcd2479746e69
+          mkdir flux2 && pushd flux2
+          git init
+          git remote add origin https://github.com/fluxcd/flux2
+          # git clone --depth 1 https://github.com/fluxcd/flux2 -b oci
+          git fetch --depth 1 origin $FLUX_OCI_SHA
+          git checkout FETCH_HEAD
+          # pushd flux2
           FLUX_OCI_SHA=$(git rev-parse --short HEAD)
           popd
           mkdir -p "${FLUX_PATH}"

--- a/deploy/experiment/ocirepository.yaml
+++ b/deploy/experiment/ocirepository.yaml
@@ -7,4 +7,4 @@ spec:
   interval: 1m0s
   ref:
     tag: 0.5.11 # {"$imagepolicy": "river-auto:edge-config:tag"}
-  url: oci://ghcr.io/kingdonb/river-data-explorer-config
+  url: ghcr.io/kingdonb/river-data-explorer-config


### PR DESCRIPTION
The version that worked is a few commits back. Work began on adding the `oci://` url prefix but it has not wrapped and will likely stay WIP for some time.